### PR TITLE
Initialize the issue_id directly on submit

### DIFF
--- a/www/submit.php
+++ b/www/submit.php
@@ -26,6 +26,7 @@ foreach($_POST as $k => $v) {
 // Add custom data
 $object['added_date'] = time();
 $object['status'] = STATE_NEW;
+$object['issue_id'] = bicou_issue_id($object['stack_trace'], $object['package_name']);
 
 // Save to DB
 $sql = bicou_mysql_insert($object);


### PR DESCRIPTION
Hi,
First, thanks for work, it's great to find a simple functional tool to store and manage ACRA crash reports.
I just pushed a tiny modification that initialize the issue_id field directly when a crash report is submitted.
Previously the issue_id was initialized during the method display_crashes, and if there was several issues behind a line, it would initialize only one crash issue_id. It was necessary to reload the page N times for N similar crashes.

Regards,
~ Florian Minjat
